### PR TITLE
fix types resolution + UTF16Decoder missing

### DIFF
--- a/dist/h3-js.js
+++ b/dist/h3-js.js
@@ -457,8 +457,6 @@ var libh3 = function (libh3) {
     return stringToUTF8Array(str, HEAPU8, outPtr, maxBytesToWrite);
   }
 
-  var UTF16Decoder = typeof TextDecoder !== "undefined" ? new TextDecoder("utf-16le") : undefined;
-
   function writeArrayToMemory(array, buffer) {
     HEAP8.set(array, buffer);
   }

--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -1,7 +1,7 @@
 /**
  * @module h3
  */
-declare module "h3-js" {
+declare module "h3-reactnative" {
     /**
      * 64-bit hexidecimal string representation of an H3 index
      * @static


### PR DESCRIPTION
Fixed errors faced while trying to use this library in a typescript react-native project
- Fixed types module name
- Removed unused declaration for `UTF16Decoder`
